### PR TITLE
feat: implements keyboard shortcuts for simulation controls

### DIFF
--- a/frontend/src/pages/Home/HomePage.jsx
+++ b/frontend/src/pages/Home/HomePage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../Auth/AuthContext.jsx";
+import useKeyboardShortcuts from "../../utils/useKeyboardShortcuts.js";
 import ScenarioGrid from "./components/ScenarioGrid.jsx";
 import ScenarioDetailsModal from "./components/ScenarioDetailsModal.jsx";
 import ImportModal from "./components/ImportModal.jsx";
@@ -144,6 +145,26 @@ function HomePage() {
   const closeExportModal = () => setShowExportModal(false);
   const openCreateScenarioModal = () => setShowCreateScenarioModal(true);
   const closeCreateScenarioModal = () => setShowCreateScenarioModal(false);
+
+  // Keyboard shortcut to close modals with Escape
+  const closeAllModals = useCallback(() => {
+    if (selectedScenario) {
+      closeScenarioDetails();
+    } else if (showImportModal) {
+      closeImportModal();
+    } else if (showExportModal) {
+      closeExportModal();
+    } else if (showCreateScenarioModal) {
+      closeCreateScenarioModal();
+    }
+  }, [selectedScenario, showImportModal, showExportModal, showCreateScenarioModal]);
+
+  const hasOpenModal = selectedScenario || showImportModal || showExportModal || showCreateScenarioModal;
+
+  useKeyboardShortcuts(
+    useMemo(() => ({ Escape: closeAllModals }), [closeAllModals]),
+    { enabled: hasOpenModal }
+  );
 
   const loadSessionSummaries = useCallback(async () => {
     const parsedUserId = Number.parseInt(user?.id, 10);

--- a/frontend/src/pages/Simulation/SimulationPage.css
+++ b/frontend/src/pages/Simulation/SimulationPage.css
@@ -946,3 +946,31 @@
     gap: var(--ehr-spacing-xs);
   }
 }
+
+/* Keyboard shortcut hints */
+.keyboard-hint {
+  display: inline-block;
+  margin-left: var(--ehr-spacing-xs);
+  padding: 0 0.35em;
+  font-size: 0.7em;
+  font-weight: 500;
+  font-family: var(--ehr-font-mono);
+  color: inherit;
+  opacity: 0.6;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.control-btn .keyboard-hint {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.simulation-tab .keyboard-hint {
+  opacity: 0.5;
+}
+
+.simulation-tab.active .keyboard-hint {
+  background-color: rgba(255, 255, 255, 0.2);
+  opacity: 0.7;
+}

--- a/frontend/src/pages/Simulation/SimulationPage.jsx
+++ b/frontend/src/pages/Simulation/SimulationPage.jsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../Auth/AuthContext.jsx";
+import useKeyboardShortcuts from "../../utils/useKeyboardShortcuts.js";
 import PatientInfoSidebar from "./components/PatientInfoSidebar.jsx";
 import VitalSignsTab from "./components/VitalSignsTab.jsx";
 import ActiveMedicationsTab from "./components/ActiveMedicationsTab.jsx";
@@ -41,6 +42,7 @@ function SimulationPage() {
   const [sessionSummary, setSessionSummary] = useState(null);
 
   const pollingRef = useRef(null);
+  const notesTextareaRef = useRef(null);
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -309,6 +311,35 @@ function SimulationPage() {
     navigate("/home");
   };
 
+  // Keyboard shortcuts
+  const shortcuts = useMemo(
+    () => ({
+      Space: () => {
+        const ended = sessionState?.status === "ended";
+        if (ended) return;
+        if (sessionState?.status === "running") {
+          handlePause();
+        } else if (sessionState?.status === "paused") {
+          handleResume();
+        }
+      },
+      Escape: () => {
+        const ended = sessionState?.status === "ended";
+        if (!ended && window.confirm("End the simulation?")) {
+          handleEnd();
+        }
+      },
+      "1": () => setActiveTab("vitals"),
+      "2": () => setActiveTab("medications"),
+      "3": () => setActiveTab("orders"),
+      "4": () => setActiveTab("medAdmin"),
+      n: () => notesTextareaRef.current?.focus(),
+    }),
+    [sessionState?.status]
+  );
+
+  useKeyboardShortcuts(shortcuts, { ignoreInputs: true, enabled: !loading && !error });
+
   if (loading) {
     return (
       <div className="simulation-page">
@@ -347,14 +378,14 @@ function SimulationPage() {
         <main className="simulation-main">
           {/* tab navigation */}
           <nav className="simulation-tabs">
-            {TABS.map((tab) => (
+            {TABS.map((tab, index) => (
               <button
                 key={tab.id}
                 type="button"
                 className={`simulation-tab ${activeTab === tab.id ? "active" : ""}`}
                 onClick={() => setActiveTab(tab.id)}
               >
-                {tab.label}
+                {tab.label} <span className="keyboard-hint">[{index + 1}]</span>
               </button>
             ))}
           </nav>
@@ -419,6 +450,7 @@ function SimulationPage() {
             noteError={noteError}
             noteDeletingId={noteDeletingId}
             disabled={isEnded}
+            textareaRef={notesTextareaRef}
           />
 
           {/* session summary (when ended) */}
@@ -450,17 +482,17 @@ function SimulationPage() {
         <div className="control-actions">
           {!isEnded && sessionState?.status === "running" && (
             <button type="button" className="control-btn warning" onClick={handlePause}>
-              Pause
+              Pause <span className="keyboard-hint">[Space]</span>
             </button>
           )}
           {!isEnded && sessionState?.status === "paused" && (
             <button type="button" className="control-btn success" onClick={handleResume}>
-              Resume
+              Resume <span className="keyboard-hint">[Space]</span>
             </button>
           )}
           {!isEnded && (
             <button type="button" className="control-btn danger" onClick={handleEnd}>
-              End Simulation
+              End Simulation <span className="keyboard-hint">[Esc]</span>
             </button>
           )}
         </div>

--- a/frontend/src/pages/Simulation/components/NotesSection.jsx
+++ b/frontend/src/pages/Simulation/components/NotesSection.jsx
@@ -8,6 +8,7 @@ function NotesSection({
   noteError,
   noteDeletingId,
   disabled,
+  textareaRef,
 }) {
   const formatTimestamp = (timestamp) => {
     if (!timestamp) return "";
@@ -28,6 +29,7 @@ function NotesSection({
 
       <form className="notes-form" onSubmit={onAddNote}>
         <textarea
+          ref={textareaRef}
           className="notes-input"
           placeholder="Add a note about your observations..."
           value={noteContent}

--- a/frontend/src/utils/useKeyboardShortcuts.js
+++ b/frontend/src/utils/useKeyboardShortcuts.js
@@ -1,0 +1,83 @@
+import { useEffect, useCallback } from "react";
+
+/**
+ * Custom hook for declarative keyboard shortcut handling.
+ *
+ * @param {Object} shortcuts - Map of keyboard shortcuts to handlers
+ *   Keys can be simple like "Escape", "Space", "1" or with modifiers like "ctrl+s", "shift+n"
+ *   Handlers receive the keyboard event as an argument
+ * @param {Object} options - Configuration options
+ * @param {boolean} options.ignoreInputs - If true, ignores events when focus is in text inputs (default: true)
+ * @param {boolean} options.enabled - If false, all shortcuts are disabled (default: true)
+ *
+ * @example
+ * useKeyboardShortcuts({
+ *   "Space": () => togglePause(),
+ *   "Escape": () => closeModal(),
+ *   "1": () => setTab("vitals"),
+ *   "n": () => focusNotes(),
+ * }, { ignoreInputs: true });
+ */
+function useKeyboardShortcuts(shortcuts, options = {}) {
+    const { ignoreInputs = true, enabled = true } = options;
+
+    const handleKeyDown = useCallback(
+        (event) => {
+            if (!enabled) return;
+
+            // Check if focus is in an input element
+            if (ignoreInputs) {
+                const target = event.target;
+                const tagName = target.tagName.toLowerCase();
+                const isInput =
+                    tagName === "input" ||
+                    tagName === "textarea" ||
+                    tagName === "select" ||
+                    target.isContentEditable;
+
+                if (isInput) return;
+            }
+
+            // Normalize the key
+            let key = event.key;
+
+            // Handle special keys
+            if (key === " ") key = "Space";
+
+            // Build modifier prefix
+            const modifiers = [];
+            if (event.ctrlKey || event.metaKey) modifiers.push("ctrl");
+            if (event.altKey) modifiers.push("alt");
+            if (event.shiftKey) modifiers.push("shift");
+
+            // Try to find matching shortcut (with and without modifiers)
+            const keyWithModifiers =
+                modifiers.length > 0 ? `${modifiers.join("+")}+${key.toLowerCase()}` : null;
+            const simpleKey = key;
+            const lowerKey = key.toLowerCase();
+
+            // Check for handler (try modifier version first, then exact key, then lowercase)
+            const handler =
+                (keyWithModifiers && shortcuts[keyWithModifiers]) ||
+                shortcuts[simpleKey] ||
+                shortcuts[lowerKey];
+
+            if (handler && typeof handler === "function") {
+                event.preventDefault();
+                handler(event);
+            }
+        },
+        [shortcuts, ignoreInputs, enabled]
+    );
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => {
+            window.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [handleKeyDown, enabled]);
+}
+
+export default useKeyboardShortcuts;


### PR DESCRIPTION
Adds keyboard shortcuts to improve user efficiency during simulations. Adds useKeyboardShortcuts hook that handles shortcut inputs. On the simulation page, users can now press Space to pause/resume, 1-4 to switch tabs, N to focus the notes textarea, and Escape to end the simulation. On the home page, Escape closes any open modal. Visual hints on buttons and tabs indicate available shortcuts.