### PR TITLE
feat: persist login session across app restarts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,3 +24,6 @@ Documentation for scenario sharing features.
 ## Features
 
 - [scenario-filters.md](./features/scenario-filters.md) - Scenario filtering functionality
+- [duplicate-scenario.md](./features/duplicate-scenario.md) - Duplicate scenario functionality
+- [scenario-authoring.md](./features/scenario-authoring.md) - Creating scenarios with the multi-section form
+- [session-summary-pdf-export.md](./features/session-summary-pdf-export.md) - Session action logging, summaries, and PDF export

--- a/docs/features/scenario-authoring.md
+++ b/docs/features/scenario-authoring.md
@@ -1,0 +1,147 @@
+# Scenario Authoring Feature
+
+## Overview
+Instructors and admins can create custom simulation scenarios directly within the app using a multi-section form. Each scenario fully configures the patient context, initial vital signs, medications, provider orders, simulation parameters, and optional custom documentation tabs that students interact with during a session.
+
+## Access
+The **Create Scenario** button appears on the Home page only for users with the `instructor` or `admin` role. Students do not see it.
+
+## User Flow
+
+1. **Open the modal**
+   - Click **Create Scenario** on the Home page
+
+2. **Fill out each section** (described below)
+
+3. **Submit**
+   - Click **Create Scenario** in the modal footer
+   - On success the modal closes and the scenario grid refreshes automatically
+   - On validation error a message appears at the bottom of the form
+
+## Form Sections
+
+### Scenario Name
+- Required free-text field
+- Used as the display title on scenario cards and in session summaries
+
+### Patient Information
+| Field | Required | Notes |
+|---|---|---|
+| Patient Name | Yes | |
+| Age | Yes | |
+| Gender | Yes | Male / Female / Other |
+| MRN | No | Auto-generated as `MRN-<timestamp>` if left blank |
+| Primary Diagnosis | Yes | Also used as the default tag if no tags are added |
+| Room | No | |
+| Attending Physician | No | |
+| Allergies | No | Dynamic list — each entry has substance, reaction, and severity (Mild / Moderate / Severe) |
+
+### Vital Signs
+Sets the simulation's **initial state**. All values are numbers. Required fields are marked below.
+
+| Vital | Required | Default |
+|---|---|---|
+| Systolic BP (mmHg) | Yes | — |
+| Diastolic BP (mmHg) | Yes | — |
+| Heart Rate (bpm) | Yes | — |
+| Respiratory Rate (breaths/min) | Yes | — |
+| Temperature (°F) | No | 98.6 |
+| O2 Saturation (%) | No | 98 |
+| Pain Level (0–10) | No | 0 |
+| Weight (lbs) | No | 150 |
+
+### Medications
+Dynamic list of medications the patient is on. At least one medication with a name and dosage is required.
+
+| Field | Notes |
+|---|---|
+| Name | Medication name |
+| Dose | Current dose value |
+| Route | PO / IV / IM / SubQ / Topical |
+| Frequency | Free text (e.g., "Q4H PRN") |
+| Indication | Free text |
+| PRN | Checkbox |
+
+> **Titration** — every medication is created with a titration range (`min: 1`, `max: 100`, `step: 1`, `unit: mg` by default). If the simulation's medication effects are configured, students can adjust the dose within this range during a session from the Medication Administration tab.
+
+### Provider Orders
+Optional dynamic list of orders displayed in the Provider Orders tab during simulation. Orders do not affect the simulation engine — they are documentation only.
+
+| Field | Options |
+|---|---|
+| Type | Medication / Vital Signs / Activity / Diet / Lab / Other |
+| Description | Free text |
+| Status | Active / Pending / Completed |
+| Priority | Routine / Stat / Urgent |
+
+### Learning Objectives
+Optional dynamic list of free-text objectives. Displayed in the scenario details modal on the Home page so students know what they should focus on before starting.
+
+### Tags
+Optional dynamic list of short labels used by the search and filter system on the Home page. If no tags are added, the primary diagnosis is used as the default tag.
+
+### Simulation Parameters
+Controls how the simulation engine behaves. These fields directly affect runtime behavior.
+
+| Field | Default | Description |
+|---|---|---|
+| Tick Interval (ms) | 5000 | How often the simulation engine updates vitals. Lower = faster simulation. Range: 1000–60,000 ms. |
+| Target Systolic BP | — | Optional. If set alongside Target Diastolic, the session auto-completes when vitals reach these targets. |
+| Target Diastolic BP | — | Optional. Must be set together with Target Systolic. |
+| Hold Ticks Required | 3 | Only shown when both BP targets are set. Number of consecutive ticks vitals must stay within the target range before the session auto-completes. |
+
+### Metadata
+| Field | Default | Notes |
+|---|---|---|
+| Difficulty | Intermediate | Beginner / Intermediate / Advanced — used by the difficulty filter on Home page |
+| Estimated Duration | "30-45 minutes" | Free text — informational only |
+| Specialty | "General Nursing" | Free text — used by the specialty filter on Home page |
+
+### Custom Tabs
+Optional instructor-defined tabs that appear during a simulation alongside the four standard tabs (Vital Signs, Medications, Provider Orders, Data Assessment).
+
+- Add one or more tabs, each with a **label** (the tab name) and any number of **fields**
+- Each field has: label, type (Text / Number / Text Area), optional placeholder, and optional unit
+- Students can fill in these fields freely during a session — the values are **not** used by the simulation engine; they serve as a structured documentation workspace
+
+## Implementation Details
+
+### Frontend
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/pages/Home/HomePage.jsx` | Renders "Create Scenario" button for instructors/admins; controls modal visibility; calls `loadScenarios()` on success |
+| `frontend/src/pages/Home/components/CreateScenarioModal.jsx` | Owns all form state; runs validation; assembles the full `scenarioDefinition` object; calls `window.api.createScenario()` |
+| `frontend/src/pages/Home/components/forms/PatientInfoForm.jsx` | Patient demographics and allergies |
+| `frontend/src/pages/Home/components/forms/VitalsForm.jsx` | Initial vital sign inputs |
+| `frontend/src/pages/Home/components/forms/MedicationsForm.jsx` | Dynamic medication list |
+| `frontend/src/pages/Home/components/forms/OrdersForm.jsx` | Dynamic provider orders |
+| `frontend/src/pages/Home/components/forms/LearningObjectivesForm.jsx` | Dynamic learning objectives |
+| `frontend/src/pages/Home/components/forms/TagsForm.jsx` | Dynamic tags |
+| `frontend/src/pages/Home/components/forms/SimulationParamsForm.jsx` | Tick interval, BP targets, hold ticks |
+| `frontend/src/pages/Home/components/forms/MetadataForm.jsx` | Difficulty, duration, specialty |
+| `frontend/src/pages/Home/components/forms/CustomTabsForm.jsx` | Custom tab and field builder |
+
+### Backend
+
+**IPC Handler:** `create-scenario` in `electron/main.js`
+- Requires an authenticated session (any role)
+- Calls `createScenario({ name, definition })` from `electron/database/models/scenarios.js`
+- Stores the assembled `scenarioDefinition` as a JSON string in the `definition` column of the `scenarios` table
+
+## Files Changed
+
+**Created:**
+- `docs/features/scenario-authoring.md`
+
+**Pre-existing (no changes needed):**
+- `electron/main.js` — `create-scenario` IPC handler
+- `electron/database/models/scenarios.js` — `createScenario()` function
+- `frontend/src/pages/Home/components/CreateScenarioModal.jsx`
+- `frontend/src/pages/Home/components/forms/` — all 9 sub-form components
+
+---
+
+**Author:** Trey Springer (Frontend Team)
+**Date:** March 15th, 2026
+**Sprint:** Sprint 3 of Winter Term

--- a/docs/features/session-summary-pdf-export.md
+++ b/docs/features/session-summary-pdf-export.md
@@ -1,0 +1,95 @@
+# Session Summary & PDF Export Feature
+
+## Overview
+When a simulation session ends, the app automatically generates a plain-text summary of everything that happened during the session - including all medication adjustments, pauses, resumes, and the final completion reason. Users can read the summary in-app and download it as a formatted PDF to their computer.
+
+## User Flow
+
+### During a Simulation
+Every action a student takes is silently logged in the background (no user interaction needed).
+
+### When the Session Ends
+The session can end in two ways:
+- **Manual end** - student clicks "End Simulation" and confirms
+- **Auto-completion** - vitals stay within the instructor-defined target ranges for the required number of consecutive ticks
+
+Once ended:
+1. The simulation page displays the **Session Summary** below the vitals panel
+2. A **Download PDF** button appears next to the summary heading
+3. Clicking it opens a native save dialog defaulting to the user's Documents folder with a pre-filled filename (e.g., `session-summary_Scenario-Name_42.pdf`)
+4. Choosing a save location writes the PDF to disk
+
+### After the Session (Home Page)
+- The **My Session Summaries** section at the bottom of the Home page lists all past sessions for the logged-in user
+- Each card shows the scenario name and the date/time the summary was generated
+- Clicking a card expands it to show the full summary text and a **Download PDF** button
+
+## What the Summary Contains
+
+```
+Scenario Summary
+Scenario: <scenario name>
+User: <username>
+Started: <start timestamp>
+Ended: <end timestamp>
+Completion: <reason>
+Actions (<count>):
+- <timestamp>: Started scenario: <name>
+- <timestamp>: Adjusted medication <name>: <old dose> -> <new dose>
+- <timestamp>: Paused simulation
+- <timestamp>: Resumed simulation
+- <timestamp>: Ended scenario: <reason>
+```
+
+### Logged Action Types
+
+| Action | When it's recorded |
+|---|---|
+| `session_started` | Session launches |
+| `medication_adjusted` | Student changes a medication dose (records old → new value) |
+| `session_paused` | Student pauses the simulation |
+| `session_resumed` | Student resumes after a pause |
+| `session_ended` | Session ends (manual or auto-completion, with reason) |
+
+## Implementation Details
+
+### Action Logging - `electron/database/simulation.js`
+- Every significant event calls `logSessionAction()` which writes a row to the `session_actions` table with `sessionId`, `userId`, `actionType`, `actionLabel`, and an optional `details` JSON blob
+- On session end, `buildSessionSummary(session, actions)` reads all actions for that session and assembles the plain-text summary string
+- The summary is then saved to the `session_summaries` table via `createSessionSummary()` - this only runs once per session (guarded by a check for an existing summary)
+
+### PDF Export - `electron/utils/summaryExport.js`
+- `exportSessionSummaryPdf()` receives the summary text, scenario name, username, session ID, and a suggested filename
+- Opens a native **Save As** dialog via `dialog.showSaveDialog()` defaulting to the user's Documents folder
+- Creates a hidden `BrowserWindow`, loads the summary as a styled HTML page via a `data:` URL, and calls `printToPDF()` to render it as an A4 document
+- Writes the resulting PDF buffer to the chosen path using `fs/promises.writeFile()`
+- The hidden window is always closed in a `finally` block, even if an error occurs
+
+### Frontend - Simulation Page
+- `frontend/src/pages/Simulation/SimulationPage.jsx`
+- Watches `sessionState.status` - when it becomes `"ended"`, calls `window.api.getSessionSummary(sessionId)` to load the summary from the database
+- Renders the summary text in a `<pre>` block with a **Download PDF** button
+- Button is disabled while export is in progress; a status message shows the saved file path on success or an error message on failure
+
+### Frontend - Home Page
+- `frontend/src/pages/Home/HomePage.jsx`
+- Loads all summaries for the current user via `window.api.getSessionSummaries(userId)` on mount
+- Renders an expandable accordion - one card per past session, sorted by date
+- Each expanded card has its own **Download PDF** button using the same `window.api.exportSessionSummaryPdf` IPC call
+
+## Files Involved
+
+| File | Role |
+|---|---|
+| `electron/database/simulation.js` | Action logging, `buildSessionSummary()`, `endSession()` trigger |
+| `electron/utils/summaryExport.js` | PDF rendering and file save logic |
+| `electron/main.js` | `get-session-summary`, `get-session-summaries`, `export-session-summary-pdf` IPC handlers |
+| `electron/preload.cjs` | Exposes `getSessionSummary`, `getSessionSummaries`, `exportSessionSummaryPdf` on `window.api` |
+| `frontend/src/pages/Simulation/SimulationPage.jsx` | In-session summary display and PDF export button |
+| `frontend/src/pages/Home/HomePage.jsx` | "My Session Summaries" accordion with per-summary PDF export |
+
+---
+
+**Author:** Trey Springer (Frontend Team)
+**Date:** March 15th, 2026
+**Sprint:** Sprint 3 of Winter Term

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,9 @@ import './App.css';
 
 function ProtectedRoute({ children }) {
   const location = useLocation();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, restoring } = useAuth();
+
+  if (restoring) return null;
 
   if (!isAuthenticated) {
     return <Navigate to="/sign-in" replace state={{ from: location }} />;
@@ -25,7 +27,8 @@ function ProtectedRoute({ children }) {
 }
 
 function LandingRoute() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, restoring } = useAuth();
+  if (restoring) return null;
   return <Navigate to={isAuthenticated ? '/home' : '/sign-in'} replace />;
 }
 

--- a/frontend/src/pages/Auth/AuthContext.jsx
+++ b/frontend/src/pages/Auth/AuthContext.jsx
@@ -1,23 +1,36 @@
-import { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 const AuthContext = createContext(null);
 const STORAGE_KEY = 'ehrSimulatorUser';
 
-// Always clear any persisted session on startup so the app opens at the login screen
-if (typeof window !== 'undefined') {
-  try {
-    window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    // ignore storage errors
-  }
-}
-
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
+  const [restoring, setRestoring] = useState(true);
 
-  const updateUser = (nextUser) => {
-    setUser(nextUser);
-  };
+  useEffect(() => {
+    const attemptSessionRestore = async () => {
+      try {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          const savedUser = JSON.parse(stored);
+          if (savedUser?.id && window.api?.restoreSession) {
+            const response = await window.api.restoreSession({ userId: savedUser.id });
+            if (response.success) {
+              setUser(response.user);
+            } else {
+              window.localStorage.removeItem(STORAGE_KEY);
+            }
+          }
+        }
+      } catch {
+        try { window.localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+      } finally {
+        setRestoring(false);
+      }
+    };
+
+    attemptSessionRestore();
+  }, []);
 
   const signIn = async ({ username, password }) => {
     if (typeof window === 'undefined' || !window.api?.loginUser) {
@@ -28,7 +41,8 @@ export function AuthProvider({ children }) {
       throw new Error(response.error || 'Unable to sign in.');
     }
     const nextUser = response.user;
-    updateUser(nextUser);
+    setUser(nextUser);
+    try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextUser)); } catch { /* ignore */ }
     return nextUser;
   };
 
@@ -41,7 +55,8 @@ export function AuthProvider({ children }) {
       throw new Error(response.error || 'Registration failed.');
     }
     const nextUser = response.user;
-    updateUser(nextUser);
+    setUser(nextUser);
+    try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextUser)); } catch { /* ignore */ }
     return nextUser;
   };
 
@@ -50,18 +65,19 @@ export function AuthProvider({ children }) {
       window.api.signOut();
     }
     setUser(null);
+    try { window.localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
   };
 
   const value = useMemo(
     () => ({
       user,
       isAuthenticated: Boolean(user?.id),
-      restoring: false,
+      restoring,
       signIn,
       signOut,
       register,
     }),
-    [user]
+    [user, restoring]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
Changelog:

1. Removed the module-level localStorage.removeItem that was explicitly wiping the session on every app start

2. Added a useEffect that runs once on mount: reads the saved user from localStorage, calls window.api.restoreSession({ userId }) (which already existed in the Electron main process), and if the user is still valid in the database, restores them into React state. If the user no longer exists, it clears storage cleanly

3. signIn and register now save the user object to localStorage after a successful call. signOut removes it

App.jsx: Updated ProtectedRoute and LandingRoute to return null while restoring is true. This prevents a flash where the app briefly redirects to /sign-in before the async restore finishes

Also added scenario authoring and session summary feature documentation