### PR TITLE
docs: add missing feature docs and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,103 @@
-# ehr-module-simulator
+# EHR Module Simulator
 
-The EHR Module Simulator is designed to help nursing students at OHSU practice real-world clinical decision-making and documentation in a simulated Electronic Health Record (EHR) environment.
+The EHR Module Simulator is a desktop application designed to help nursing students at OHSU practice real-world clinical decision-making and documentation in a simulated Electronic Health Record (EHR) environment.
 
-This project provides specialty learning modules that mirror realistic patient care scenarios used in clinical learning labs. Students can interact with simulated patient charts, review provider orders, interpret clinical data, and perform virtual actions such as titrating medications or documenting care, just as they would in a real EHR system.
+Students can interact with simulated patient charts, review provider orders, interpret clinical data, and perform virtual actions such as titrating medications or documenting care — just as they would in a real EHR system. Instructors can author custom scenarios, build quizzes, and review student performance.
 
-## Contact  
-Carson Gabler:  
-- ✉️ **Email:** [gablerc@oregonstate.edu](mailto:gablerc@oregonstate.edu)  
-- 💼 **LinkedIn:** [linkedin.com/in/carsongabler](https://www.linkedin.com/in/carsongabler)  
-- 🌐 **GitHub:** [github.com/cbgabler](https://github.com/cbgabler)
-- **Role:** Project Manager
+---
 
-AJ Paumier:  
-- ✉️ **Email:** [paumiera@oregonstate.edu](mailto:paumiera@oregonstate.edu)
-- **Role:** Backend Software Developer
+## Table of Contents
 
-Thien Tu:  
-- ✉️ **Email:** [tuthi@oregonstate.edu](mailto:tuthi@oregonstate.edu)
-- **Role:** Backend Software Developer
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
+- [Building for Distribution](#building-for-distribution)
+- [Project Structure](#project-structure)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
+- [Contact](#contact)
 
-Trey Springer:  
-- ✉️ **Email:** [springet@oregonstate.edu](mailto:springet@oregonstate.edu)
-- 💼 **LinkedIn:** [linkedin.com/in/treysp](https://www.linkedin.com/in/treysp/)
-- 🌐 **GitHub:** [github.com/treyspringer](https://github.com/treyspringer)
-- **Role:** Frontend Software Developer
+---
 
-Kristy Chen:  
-- ✉️ **Email:** [chenkr@oregonstate.edu](mailto:chenkr@oregonstate.edu)
-- **Role:** Frontend Software Developer
+## Features
 
-## How to Run
+- **Scenario Simulations** — Run realistic patient care scenarios with live vital sign updates, medication administration, and provider orders
+- **Scenario Authoring** — Instructors can create fully customizable scenarios via a multi-section form (patient info, vitals, medications, orders, custom tabs, and more)
+- **Vitals Trend Graph** — Real-time SVG visualization of patient vital signs over time with interactive legend and tooltips
+- **Custom Tabs** — Instructors define additional documentation sections (e.g., Urine Output, Wound Assessment) that appear alongside standard simulation tabs
+- **Quizzes** — Create, assign, and grade multiple-choice and true/false quizzes with submission history
+- **Session Summaries & PDF Export** — Automatic action logging during simulations with downloadable PDF summaries
+- **Scenario Import/Export** — Share scenarios between app instances via SQLite database files
+- **Search & Filters** — Find scenarios by name, diagnosis, difficulty, specialty, or tags
+- **Keyboard Shortcuts** — Navigate tabs, pause/resume simulations, and control the app without a mouse
+- **Role-Based Access** — Student and Instructor roles with appropriate UI controls
+- **Offline-First** — Runs entirely offline with a local SQLite database
+
+---
+
+## Tech Stack
+
+| Layer | Technologies |
+|---|---|
+| **Frontend** | React 19, React Router, Vite, Vanilla CSS |
+| **Desktop Shell** | Electron, Electron Forge |
+| **Database** | SQLite via better-sqlite3 |
+| **Build & CI** | GitHub Actions, ESLint, Prettier |
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v18 or later
+- npm (included with Node.js)
+
+---
+
+## Getting Started
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/cbgabler/ehr-module-simulator.git
+cd ehr-module-simulator
 ```
-cd src
-npm run dev
+
+### 2. Install dependencies
+
+```bash
+cd frontend
+npm install
+
 cd ../electron
+npm install
+```
+
+### 3. Run in development mode
+
+In one terminal, start the React dev server:
+```bash
+cd frontend
+npm run dev
+```
+
+In a second terminal, start the Electron shell:
+```bash
+cd electron
 npm start
 ```
+
+### Default Accounts
+
+| Role | Username | Password |
+|---|---|---|
+| Instructor | `instructor1` | `password123` |
+| Student | `student1` | `password123` |
+
+> **Note:** These are demo accounts. Create individual accounts for production use.
+
+---
 
 ## Building for Distribution
 
@@ -55,22 +117,67 @@ This will automatically:
 - **Windows:** `electron/out/make/squirrel.windows/x64/EHR Module Simulator-1.0.0 Setup.exe`
 - **macOS:** `electron/out/make/dmg/EHR Module Simulator-1.0.0.dmg`
 
-**Notes:**
-- Electron cannot cross-compile — Windows installers must be built on Windows, macOS installers on a Mac.
+> Electron cannot cross-compile — Windows installers must be built on Windows, macOS installers on a Mac.
 
-## Branching Strategy
+---
 
-This project follows a structured branching strategy to ensure efficient collaboration and workflow:
+## Project Structure
 
-### Branch Types
-1. **`main`**: Long-running branch for production-ready code.  
-2. **`feat/[topic-name]`**: Feature-specific branches created from `main`. Use for implementing features or fixes.  
-3. **`feat/[topic-name]-topic/[subtopic-name]`**: Sub-branches for collaboration on feature parts. Created from `feat/[topic-name]`.  
+```
+ehr-module-simulator/
+├── frontend/               # React + Vite frontend
+│   └── src/
+│       ├── pages/          # Page components (Auth, Home, Simulation, Quizzes)
+│       ├── utils/          # Shared hooks and helpers
+│       └── App.jsx         # Router and protected routes
+├── electron/               # Electron main process
+│   ├── database/           # SQLite models, migrations, and queries
+│   ├── utils/              # PDF export and other utilities
+│   ├── main.js             # IPC handlers and app lifecycle
+│   └── preload.cjs         # Context bridge API
+├── docs/                   # Project documentation
+│   ├── features/           # Feature documentation
+│   ├── database/           # Schema and versioning docs
+│   └── import-export/      # Import/export guides
+└── .github/                # CI workflows and code owners
+```
 
-### Commit Messages
-Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for clarity:
-- `fix:` Minor fixes or tweaks.
-- `feat:` New features or enhancements.
-- `chore:` Routine updates (e.g., dependency upgrades).
-- `config:` Configuration changes.
-- `merge:` Merge activity.
+---
+
+## Documentation
+
+Full project documentation is available in the [`docs/`](docs/README.md) directory, including:
+
+- [Installation Guide](docs/installation-guide.md) — End-user setup instructions
+- [Contributing Guide](docs/contributions.md) — Development workflow and standards
+- [Database Schema](docs/database/schema.md) — Complete database reference
+- [Feature Docs](docs/features/) — Detailed documentation for each feature
+
+---
+
+## Contributing
+
+1. Fork and clone the repository
+2. Create a feature branch: `git checkout -b feat/your-feature`
+3. Commit using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (`feat:`, `fix:`, `chore:`, etc.)
+4. Push and open a Pull Request against `main`
+
+See the full [Contributing Guide](docs/contributions.md) for branching strategy, code style, PR requirements, and CI details.
+
+---
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+---
+
+## Contact
+
+| Name | Role | Email |
+|---|---|---|
+| Carson Gabler | Project Manager | [gablerc@oregonstate.edu](mailto:gablerc@oregonstate.edu) |
+| AJ Paumier | Backend Developer | [paumiera@oregonstate.edu](mailto:paumiera@oregonstate.edu) |
+| Thien Tu | Backend Developer | [tuthi@oregonstate.edu](mailto:tuthi@oregonstate.edu) |
+| Trey Springer | Frontend Developer | [springet@oregonstate.edu](mailto:springet@oregonstate.edu) |
+| Kristy Chen | Frontend Developer | [chenkr@oregonstate.edu](mailto:chenkr@oregonstate.edu) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,12 @@ Documentation for scenario sharing features.
 
 ## Features
 
+- [authentication.md](./features/authentication.md) - Sign in, registration, roles, and session management
+- [scenario-authoring.md](./features/scenario-authoring.md) - Creating scenarios with the multi-section form
 - [scenario-filters.md](./features/scenario-filters.md) - Scenario filtering functionality
 - [duplicate-scenario.md](./features/duplicate-scenario.md) - Duplicate scenario functionality
-- [scenario-authoring.md](./features/scenario-authoring.md) - Creating scenarios with the multi-section form
+- [custom-tabs.md](./features/custom-tabs.md) - Instructor-defined custom tabs for simulations
+- [vitals-trend-graph.md](./features/vitals-trend-graph.md) - Real-time SVG vital signs visualization
+- [keyboard-shortcuts.md](./features/keyboard-shortcuts.md) - Global keyboard shortcuts system
 - [session-summary-pdf-export.md](./features/session-summary-pdf-export.md) - Session action logging, summaries, and PDF export
+- [quizzes.md](./features/quizzes.md) - Quiz creation, assignment, grading, and history

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -1,0 +1,58 @@
+# Authentication & User Management
+
+## Overview
+The EHR Module Simulator uses a local authentication system with role-based access control. Users can sign in or register accounts directly within the app. Roles determine what actions are available — instructors can create/manage scenarios and quizzes, while students interact with simulations and take quizzes.
+
+## Roles
+
+| Role | Capabilities |
+|---|---|
+| **Student** | Start simulations, take quizzes, view session summaries, import/export scenarios |
+| **Instructor** | Everything a student can do, plus: create/edit/delete/duplicate scenarios, create/edit/delete quizzes, assign quizzes to students |
+| **Admin** | Same as instructor (reserved for future elevated permissions) |
+
+## User Flow
+
+### Sign In
+1. Enter username and password on the Sign In page
+2. Credentials are validated against the local SQLite database via `window.api.loginUser()`
+3. On success, the user object is stored in React context (`AuthContext`) and persisted to `localStorage` for session restoration
+
+### Register
+1. Switch to "Create Account" mode on the Sign In page
+2. Enter username, password (minimum 6 characters), confirm password, and select a role (Student or Instructor)
+3. Account is created via `window.api.registerUser()` and the user is signed in automatically
+
+### Session Persistence
+- On app launch, `AuthContext` checks `localStorage` for a saved user
+- If found, it calls `window.api.restoreSession()` to verify the user still exists in the database
+- If the session is invalid or the user has been deleted, the stored data is cleared and the user is redirected to Sign In
+
+### Sign Out
+- Clicking "Sign Out" in the navigation bar triggers a confirmation modal
+- On confirmation, the user state is cleared from both React context and `localStorage`
+- The user is redirected to the Sign In page
+
+## Protected Routes
+All pages except Sign In are wrapped in a `ProtectedRoute` component that redirects unauthenticated users to `/sign-in`. The redirect preserves the original destination so the user returns to the correct page after signing in.
+
+## Default Accounts
+
+Two accounts are seeded automatically when the database is first created:
+
+| Role | Username | Password |
+|---|---|---|
+| Instructor | `instructor1` | `password123` |
+| Student | `student1` | `password123` |
+
+## Architecture
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/pages/Auth/AuthContext.jsx` | React context provider managing `user` state, `signIn`, `register`, `signOut`, and session restoration |
+| `frontend/src/pages/Auth/SignInPage.jsx` | Sign In / Register form UI with mode toggle and validation |
+| `frontend/src/App.jsx` | `ProtectedRoute` and `LandingRoute` components for route guarding |
+| `electron/database/models/users.js` | User database operations: create, authenticate, lookup |
+| `electron/database/seedUsers.js` | Seeds default instructor and student accounts on first run |
+| `electron/main.js` | IPC handlers: `login-user`, `register-user`, `restore-session`, `sign-out`, `get-all-users` |
+| `electron/preload.cjs` | Exposes auth API methods on `window.api` |

--- a/docs/features/quizzes.md
+++ b/docs/features/quizzes.md
@@ -1,0 +1,79 @@
+# Quizzes Feature
+
+## Overview
+The Quizzes module provides a complete assessment system that allows instructors to create, manage, and distribute quizzes to students. Students can take assigned quizzes, receive scores, and review their submission history. The feature supports role-based access, JSON import/export for quiz sharing, and configurable answer visibility.
+
+## User Flows
+
+### Instructor Flow
+1. **Create a Quiz** — Click "Create Quiz" on the Quizzes page to open the form
+2. **Add Questions** — Add multiple-choice or true/false questions with answer options, correct answer selection, and optional explanations
+3. **Configure Visibility** — Set the quiz as public (visible to all students) or assign it to specific students
+4. **Show Correct Answers** — Optionally allow students to see the correct answers after submission
+5. **Manage Quizzes** — Edit, delete, copy, or export existing quizzes from the quiz grid
+6. **Import Quizzes** — Import quizzes from JSON files shared by other instructors
+
+### Student Flow
+1. **Browse Quizzes** — View all public quizzes and quizzes assigned to you on the Quizzes page
+2. **Take a Quiz** — Click a quiz card to open the quiz panel, answer all questions, and submit
+3. **View Results** — See your score immediately after submission
+4. **Review History** — View all past submissions in the "Quiz History" section at the bottom of the page
+
+## Question Types
+
+| Type | Description |
+|---|---|
+| Multiple Choice | 2+ custom answer options; one correct answer |
+| True/False | Fixed "True" and "False" options; one correct answer |
+
+Each question also supports:
+- **Prompt** — The question text
+- **Explanation** — Optional text explaining the correct answer (shown depending on quiz settings)
+
+## Architecture
+
+### Frontend
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/pages/Quizzes/QuizzesPage.jsx` | Page-level state management, quiz CRUD handlers, submission logic |
+| `frontend/src/pages/Quizzes/components/QuizHeader.jsx` | Page heading, "Create Quiz" and "Import Quiz" buttons |
+| `frontend/src/pages/Quizzes/components/QuizCreatePanel.jsx` | Quiz creation/editing form with question builder |
+| `frontend/src/pages/Quizzes/components/QuizGrid.jsx` | Card grid displaying all available quizzes with action buttons (edit, delete, copy, export) |
+| `frontend/src/pages/Quizzes/components/QuizTakePanel.jsx` | Quiz-taking interface with question display, answer selection, and submission |
+| `frontend/src/pages/Quizzes/components/QuizHistory.jsx` | Past submission list with scores and timestamps |
+| `frontend/src/pages/Quizzes/quizUtils.js` | Helper functions for creating empty questions and normalizing quiz data |
+
+### Backend
+
+| File | Responsibility |
+|---|---|
+| `electron/database/models/quizzes.js` | Database operations: create, read, update, delete, copy, import/export quizzes and submissions |
+| `electron/main.js` | IPC handlers: `create-quiz`, `get-all-quizzes`, `get-quiz`, `update-quiz`, `delete-quiz`, `copy-quiz`, `submit-quiz`, `get-user-quiz-submissions`, `export-quiz`, `import-quiz` |
+| `electron/preload.cjs` | Exposes quiz API methods on `window.api` |
+
+## Data Model
+
+### Quiz
+- `id` — Auto-incrementing primary key
+- `title` — Quiz display name
+- `description` — Optional description text
+- `createdBy` — User ID of the instructor who created the quiz
+- `isPublic` — Boolean; if true, all students can see the quiz
+- `showCorrectAnswers` — Boolean; if true, students see correct answers after submission
+- `questions` — JSON array of question objects (stored as TEXT)
+- `assignedStudentIds` — JSON array of student user IDs (stored as TEXT)
+
+### Quiz Submission
+- `id` — Auto-incrementing primary key
+- `quizId` — Foreign key to the quiz
+- `userId` — User who submitted
+- `answers` — JSON array of answer objects
+- `score` — Calculated score (number correct)
+- `total` — Total number of questions
+
+## Import/Export
+
+Quizzes can be shared between app instances via JSON files:
+- **Export**: Instructor selects a quiz → chooses a save location → quiz definition is written as a `.json` file
+- **Import**: Instructor selects a `.json` file → quiz is validated and inserted into the local database with a new ID


### PR DESCRIPTION
Added feature documentation for Quizzes and Authentication, which were previously undocumented. Updated the docs index to include all 9 feature docs. Rewrote the repo README; added a table of contents, features overview, tech stack, prerequisites, project structure, and links to docs and contributing guide. Also fixed the incorrect setup directory (cd src → cd frontend).